### PR TITLE
Changed http_errors to false

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -52,6 +52,7 @@ class Client
     {
         return $this->client ?? new GuzzleClient([
             'base_uri' => "{$this->url}/api/rest/",
+            'http_errors' => false,
             'headers' => [
                 'Accept' => 'application/json',
                 'Authorization' => $this->token,


### PR DESCRIPTION
So all exceptions are handled by the client instead of Guzzle.